### PR TITLE
chore: bump to .NET 10, add CI/release pipeline, Dependabot, README

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/FL.DriveMapper"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    groups:
+      nuget-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,28 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for minor/patch and GitHub Actions updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.package-ecosystem == 'github_actions'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore
+        run: dotnet restore FL.DriveMapper.sln
+
+      - name: Build
+        run: dotnet build FL.DriveMapper.sln -c Release --no-restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version (e.g. 1.2.3) — used when running manually"
+        required: true
+        default: "0.0.0"
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        rid: [win-x64, win-x86, win-arm64]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Resolve version
+        id: ver
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_REF -like "refs/tags/v*") {
+            $v = $env:GITHUB_REF -replace "^refs/tags/v", ""
+          } else {
+            $v = "${{ github.event.inputs.version }}"
+          }
+          echo "version=$v" >> $env:GITHUB_OUTPUT
+
+      - name: Publish (${{ matrix.rid }})
+        run: >
+          dotnet publish FL.DriveMapper/FL.DriveMapper.csproj
+          -c Release
+          -r ${{ matrix.rid }}
+          --self-contained true
+          -p:PublishSingleFile=true
+          -p:IncludeNativeLibrariesForSelfExtract=true
+          -p:Version=${{ steps.ver.outputs.version }}
+          -p:AssemblyVersion=${{ steps.ver.outputs.version }}.0
+          -p:FileVersion=${{ steps.ver.outputs.version }}.0
+          -o publish/${{ matrix.rid }}
+
+      - name: Stage release files
+        shell: pwsh
+        run: |
+          $stage = "stage/${{ matrix.rid }}"
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+          Copy-Item "publish/${{ matrix.rid }}/FL.DriveMapper.exe" $stage
+          Copy-Item "publish/${{ matrix.rid }}/DriveMappings.xml" $stage
+          Copy-Item "TaskSchedulerSetting.xml" $stage
+          Copy-Item "README.md" $stage
+          Copy-Item "LICENSE" $stage
+
+      - name: Zip artifact
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "stage/${{ matrix.rid }}/*" -DestinationPath "FL.DriveMapper-${{ steps.ver.outputs.version }}-${{ matrix.rid }}.zip"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: FL.DriveMapper-${{ matrix.rid }}
+          path: FL.DriveMapper-${{ steps.ver.outputs.version }}-${{ matrix.rid }}.zip
+
+  release:
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*.zip
+          generate_release_notes: true

--- a/FL.DriveMapper/FL.DriveMapper.csproj
+++ b/FL.DriveMapper/FL.DriveMapper.csproj
@@ -2,8 +2,12 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0-windows</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
+        <RuntimeIdentifiers>win-x64;win-x86;win-arm64</RuntimeIdentifiers>
+        <Version>1.0.0</Version>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <FileVersion>1.0.0.0</FileVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,91 @@
 # DriveMapper
-Mapping network drives according to a configuration file for use with Adobe Lightroom
+
+A small Windows command-line utility that maps local drive letters to network shares (or local paths) using `subst.exe` and assigns them friendly labels via the registry. Built primarily so Adobe Lightroom can find catalog folders behind a stable drive letter even when the underlying network path changes.
+
+## Why?
+
+Lightroom binds catalogs and previews to drive letters. A regular Windows mapped network drive (`net use`) is not always treated identically to a local drive by every application. `subst` produces what looks like a local drive — which Lightroom is happy with — and DriveMapper automates creating those substitutions on every login, optionally waiting for the file server to be reachable first.
+
+## How it works
+
+For every entry in `DriveMappings.xml` the tool:
+
+1. If the path is a UNC path (`\\server\share`), pings the host until it replies (up to ~4 minutes) so it works even when started before the network is fully up.
+2. Runs `subst <Drive> <NetworkPath>` to create the drive letter.
+3. Writes the configured label into `HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\MountPoints2\...\_LabelFromReg` so Explorer shows a friendly name.
+
+## Installation
+
+### Option 1 — Download a release (recommended)
+
+1. Grab the latest `FL.DriveMapper-<version>-win-x64.zip` from the [Releases page](../../releases) (use `win-arm64` on ARM machines).
+2. Extract it somewhere stable, e.g. `C:\Tools\DriveMapper\`.
+3. Edit `DriveMappings.xml` to match your shares (see below).
+4. Register it to run at logon — see *Run at logon* below.
+
+The published binary is self-contained: no .NET runtime install required.
+
+### Option 2 — Build from source
+
+Requirements: .NET 10 SDK.
+
+```powershell
+dotnet publish FL.DriveMapper/FL.DriveMapper.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o publish
+```
+
+The resulting `publish/FL.DriveMapper.exe` is a single self-contained executable.
+
+## Configuration
+
+`DriveMappings.xml` lives next to the executable. Example:
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<DriveMappings>
+  <Mappings>
+    <DriveMapInfo>
+      <Drive>L:</Drive>
+      <NetworkPath>\\sepp\projekte</NetworkPath>
+      <Label>Projekte Lightroom</Label>
+    </DriveMapInfo>
+    <DriveMapInfo>
+      <Drive>M:</Drive>
+      <NetworkPath>\\sepp\medien</NetworkPath>
+      <Label>Medien</Label>
+    </DriveMapInfo>
+  </Mappings>
+</DriveMappings>
+```
+
+| Field         | Meaning                                                  |
+| ------------- | -------------------------------------------------------- |
+| `Drive`       | The drive letter to create, e.g. `L:`                    |
+| `NetworkPath` | The target — either a UNC path or a local folder         |
+| `Label`       | The display name shown in Explorer for the mapped drive  |
+
+## Run at logon
+
+A ready-to-import Windows Task Scheduler definition is shipped as `TaskSchedulerSetting.xml`.
+
+1. Open **Task Scheduler** → **Import Task...**
+2. Select `TaskSchedulerSetting.xml`.
+3. Adjust the **Action → Program/script** path to point at your `FL.DriveMapper.exe`.
+4. On the **General** tab, change **User** to your own account.
+
+The task triggers at logon and runs with least-privilege; no admin rights are needed since `subst` and the relevant registry keys are per-user.
+
+## Logs
+
+`log4net` is used for diagnostics. Drop a `log4net.config` file next to the executable and configure appenders as you like; without it the tool runs silently.
+
+## Releases & versioning
+
+Pushing a tag `vX.Y.Z` to `master` triggers the `Release` workflow which builds self-contained single-file executables for `win-x64`, `win-x86`, and `win-arm64` and publishes a GitHub Release with one zip per architecture.
+
+## Contributing
+
+Dependencies are kept current automatically via Dependabot. Minor and patch NuGet updates as well as GitHub Actions updates are auto-merged once CI passes; major upgrades are opened as PRs for review.
+
+## License
+
+MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- **Deps:** `log4net` was already current (3.3.0). Bumped `TargetFramework` from `net8.0` → `net10.0-windows` (new LTS, Nov 2025) and added `RuntimeIdentifiers` for `win-x64`, `win-x86`, `win-arm64`.
- **Dependabot:** weekly NuGet + GitHub Actions updates, grouped so minor/patch bumps land in a single PR.
- **Auto-merge:** workflow auto-merges Dependabot PRs that are minor/patch NuGet updates *or* any GitHub Actions update, once CI passes. Major upgrades stay manual.
- **CI:** builds the solution on every push/PR (`windows-latest`, .NET 10).
- **Release pipeline:** pushing a `v*.*.*` tag triggers a matrix build that produces self-contained single-file `FL.DriveMapper.exe` binaries for each Windows RID, zips them along with `DriveMappings.xml`, `TaskSchedulerSetting.xml`, `README.md`, and `LICENSE`, and attaches them to a GitHub Release with auto-generated notes. `workflow_dispatch` is also wired up for manual one-off builds.
- **README:** filled in with purpose, how it works, install (download zip or build), config schema, scheduled-task setup, and release process.

## Distribution proposal
The simplest, lowest-friction install path for end users:

1. **GitHub Releases** with a self-contained, single-file `FL.DriveMapper.exe` per Windows architecture (this PR). Users unzip, edit `DriveMappings.xml`, import the included Task Scheduler XML. No .NET runtime install needed.
2. *(Future, optional)* Submit a manifest to **winget** so installation becomes `winget install FilmLiga.DriveMapper`. winget can pull straight from the GitHub Release zip.
3. *(Future, optional)* If a guided installer is wanted, wrap the published exe with **Inno Setup** or **WiX** to drop the binary, write a sample config, and register the scheduled task in one step.

Going with option 1 first keeps the surface area minimal; option 2 is a low-effort follow-up once a release exists.

## Test plan
- [ ] CI workflow runs green on this PR.
- [ ] Tag a `v0.1.0` (or use **Run workflow** with a version) and verify the Release workflow uploads three zips.
- [ ] On a clean Windows machine, extract `win-x64` zip, edit `DriveMappings.xml`, run `FL.DriveMapper.exe`, confirm `subst`-based drive appears with the configured label.
- [ ] Wait for first Dependabot PR; confirm it auto-merges after CI for a minor/patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)